### PR TITLE
Fix not updating if calling using same image path with different data

### DIFF
--- a/ksetwallpaper
+++ b/ksetwallpaper
@@ -22,6 +22,7 @@ wallpaper_set_script="var allDesktops = desktops();
         d = allDesktops[i];
         d.wallpaperPlugin = '${type}';
         d.currentConfigGroup = Array('Wallpaper', '${type}', 'General');
+        d.writeConfig('Image', 'file:///dev/null')
         d.writeConfig('$write', 'file://${full_image_path}')
     }"
 


### PR DESCRIPTION
Sets image to /dev/null then back to tell it to update.
I'm using this in a script that on repeat will download an image to a file
#1 